### PR TITLE
fix last fragment completion from tree

### DIFF
--- a/coffee/omelette.coffee
+++ b/coffee/omelette.coffee
@@ -65,7 +65,7 @@ class Omelette extends EventEmitter
     for level in [1..depth]
       @on "$#{level}", ({ fragment, reply, line })->
         accessor = new Function '_', """
-          return _['#{line.split(/\s+/).slice(1).filter(Boolean).join("']['")}']
+          return _['#{line.split(/\s+/).slice(1, -1).filter(Boolean).join("']['")}']
         """
         replies = if fragment is 1 then Object.keys(objectTree) else accessor(objectTree)
         reply do (replies = replies)->

--- a/src/omelette.js
+++ b/src/omelette.js
@@ -98,7 +98,7 @@
         this.on("$" + level, function(arg) {
           var accessor, fragment, line, replies, reply;
           fragment = arg.fragment, reply = arg.reply, line = arg.line;
-          accessor = new Function('_', "return _['" + (line.split(/\s+/).slice(1).filter(Boolean).join("']['")) + "']");
+          accessor = new Function('_', "return _['" + (line.split(/\s+/).slice(1, -1).filter(Boolean).join("']['")) + "']");
           replies = fragment === 1 ? Object.keys(objectTree) : accessor(objectTree);
           return reply((function(replies) {
             if (replies instanceof Function) {


### PR DESCRIPTION
Example with tree doesn't work as expected:

code:
```
omelette('hello').tree({
  cruel: ['world', 'moon'],
  beautiful: ['mars', 'pluto']
}).init();
```
cli:
```
> hello <tab>
cruel beautiful
> hello c<tab>
> hello cruel 
> hello cruel <tab>
world moon
> hello cruel w<tab>
should be: "hello cruel world", but nothing happened
```
