### PR TITLE
ignore big resource folders to shrink the size of package size

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,5 +1,0 @@
-resources/
-example/
-coffee/
-build.sh
-.travis.yml

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,5 @@
+resources/
+example/
+coffee/
+build.sh
+.travis.yml

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "zsh completion"
   ],
   "author": "Fatih Kadir Akın <fka@fatihak.in>",
-  "version": "0.4.12",
+  "version": "0.4.13",
   "licenses": [
     {
       "type": "MIT"

--- a/package.json
+++ b/package.json
@@ -7,6 +7,11 @@
     "bash completion",
     "zsh completion"
   ],
+  "files": [
+    "src",
+    "LICENSE",
+    "README.md"
+  ],
   "author": "Fatih Kadir Akın <fka@fatihak.in>",
   "version": "0.4.13",
   "licenses": [


### PR DESCRIPTION
Closes #26, closes #34. Bumps version to 0.4.13.
Unpacked size shrank from 1.5MB to 24.2kB.

Before

```
$ npm publish --dry-run
npm notice
npm notice 📦  omelette@0.4.12
npm notice === Tarball Contents ===
npm notice 581B    package.json
npm notice 59B     .travis.yml
npm notice 30B     build.sh
npm notice 1.1kB   LICENSE
npm notice 49B     npmignore
npm notice 10.7kB  README.md
npm notice 8.4kB   coffee/omelette.coffee
npm notice 1.1kB   example/githubber
npm notice 1.3kB   example/githubber-async
npm notice 641B    example/githubber-coffee
npm notice 371B    example/hello
npm notice 16.1kB  resources/logo.svg
npm notice 217.6kB resources/omelette-new-hello.gif
npm notice 123.8kB resources/omelette-new.gif
npm notice 441.9kB resources/omelette-tree-new.gif
npm notice 652.5kB resources/omelette.gif
npm notice 11.9kB  src/omelette.js
npm notice === Tarball Details ===
npm notice name:          omelette
npm notice version:       0.4.12
npm notice package size:  1.1 MB
npm notice unpacked size: 1.5 MB
npm notice shasum:        5828909c9b58fe2782569b964b8dffae1041b8e9
npm notice integrity:     sha512-GDTVVYJB36NBV[...]uyNVIF3zQ8jzQ==
npm notice total files:   17
npm notice
+ omelette@0.4.12
```

After

```
$ npm publish --dry-run
npm notice
npm notice 📦  omelette@0.4.13
npm notice === Tarball Contents ===
npm notice 581B   package.json
npm notice 1.1kB  LICENSE
npm notice 10.7kB README.md
npm notice 11.9kB src/omelette.js
npm notice === Tarball Details ===
npm notice name:          omelette
npm notice version:       0.4.13
npm notice package size:  7.9 kB
npm notice unpacked size: 24.2 kB
npm notice shasum:        a831dca4a5383d0f1c98b584cc4a6d8d92b7d747
npm notice integrity:     sha512-akJef8BPnBQsd[...]c13z3cIRn4UHg==
npm notice total files:   4
npm notice
+ omelette@0.4.13
```