### PR TITLE
Use specific version (latest, 0.53.0) of deno std

### DIFF
--- a/deno/omelette.ts
+++ b/deno/omelette.ts
@@ -1,5 +1,5 @@
-import { EventEmitter } from "https://deno.land/std/node/events.ts";
-import * as path from "https://deno.land/std/path/mod.ts";
+import { EventEmitter } from "https://deno.land/std@0.53.0/node/events.ts";
+import * as path from "https://deno.land/std@0.53.0/path/mod.ts";
 const hasProp = {}.hasOwnProperty;
 
 function depthOf(object: any) {


### PR DESCRIPTION
This will solve issues with compatibility in case someone decides to use an older version of omelette along with an older version of deno.