### PR TITLE
Change bash's default config file from `.bash_profile` to `.bashrc` when not running on MacOS

### DIFF
--- a/coffee/omelette.coffee
+++ b/coffee/omelette.coffee
@@ -37,6 +37,7 @@ class Omelette extends EventEmitter
     @word     = @line?.trim().split(/\s+/).pop()
 
     {@HOME, @SHELL} = process.env
+    {@platform} = process
     @mainProgram = ()->
 
   setProgram: (programs)->
@@ -191,7 +192,7 @@ class Omelette extends EventEmitter
     fileAtHome = fileAt @HOME
 
     switch @shell = @getActiveShell()
-      when 'bash'  then fileAtHome '.bash_profile'
+      when 'bash'  then fileAtHome (if @platform is 'darwin' then '.bash_profile' else '.bashrc')
       when 'zsh'   then fileAtHome '.zshrc'
       when 'fish'  then fileAtHome '.config/fish/config.fish'
 

--- a/src/omelette.js
+++ b/src/omelette.js
@@ -50,6 +50,7 @@
         this.line = process.argv.slice(this.compgen + 3).join(' ');
         this.word = (ref = this.line) != null ? ref.trim().split(/\s+/).pop() : void 0;
         ({HOME: this.HOME, SHELL: this.SHELL} = process.env);
+        ({platform: this.platform} = process);
         this.mainProgram = function() {};
       }
 
@@ -209,7 +210,7 @@
         fileAtHome = fileAt(this.HOME);
         switch (this.shell = this.getActiveShell()) {
           case 'bash':
-            return fileAtHome('.bash_profile');
+            return fileAtHome((this.platform === 'darwin' ? '.bash_profile' : '.bashrc'));
           case 'zsh':
             return fileAtHome('.zshrc');
           case 'fish':


### PR DESCRIPTION
Linux and other OSes usually only execute `.bash_profile` for a completely new login (when you first log in to a graphic interface, or by SSHing/using Ctrl + Alt + F1-F6), whereas MacOS uses this file on every shell.

Context:
- https://askubuntu.com/questions/121073/why-bash-profile-is-not-getting-sourced-when-opening-a-terminal
- https://apple.stackexchange.com/questions/51036/what-is-the-difference-between-bash-profile-and-bashrc