### PR TITLE
chore: remove azure-cli from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -472,7 +472,6 @@ hello <tab><tab>
 
 ## Users?
 
-- **Windows Azure** uses Omelette to support autocompletion in [azure-cli](https://github.com/WindowsAzure/azure-sdk-tools-xplat).
 - **Office 365 CLI** uses Omelette to support autocompletion in [office365-cli](https://github.com/pnp/office365-cli).
 - **Visual Studio App Center CLI** uses Omelette to support autocompletion in [appcenter-cli](https://github.com/Microsoft/appcenter-cli).
 


### PR DESCRIPTION
When I looked I could not find any usage in azure-cli, see https://github.com/Azure/azure-cli/blob/dev/src/azure-cli/az.completion.sh

I think it's fair to remove.

Nice project!